### PR TITLE
ContentWithin only GUI access

### DIFF
--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -104,7 +104,7 @@ namespace ContentsWithin {
         }
 
         if (!isVisible) {
-          if (_lastHoverContainer) {
+          if (_lastHoverContainer && PrivateArea.CheckAccess(_lastHoverContainer.transform.position, 0f, false, false)) {
             InventoryGui.instance.m_animator.SetBool("visible", true);
             InventoryGui.instance.m_hiddenFrames = 10;
             InventoryGui.instance.m_container.gameObject.SetActive(true);

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -73,12 +73,8 @@ namespace ContentsWithin {
 
       [HarmonyPrefix]
       [HarmonyPatch(nameof(InventoryGui.Show))]
-      public static void ShowPostfix(InventoryGui __instance, ref Container container) {
+      public static void ShowPostfix(InventoryGui __instance) {
         isVisible = true;
-
-        if (_isModEnabled.Value && !container && _lastHoverContainer) {
-          container = _lastHoverContainer;
-        }
       }
 
       [HarmonyPrefix]
@@ -110,11 +106,15 @@ namespace ContentsWithin {
         if (!isVisible) {
           if (_lastHoverContainer) {
             InventoryGui.instance.m_animator.SetBool("visible", true);
+            InventoryGui.instance.m_hiddenFrames = 10;
             InventoryGui.instance.m_container.gameObject.SetActive(true);
             InventoryGui.instance.m_containerGrid.UpdateInventory(_lastHoverContainer.GetInventory(), null, null);
-            InventoryGui.instance.m_hiddenFrames = 10;
+            InventoryGui.instance.m_containerGrid.ResetView();
+            InventoryGui.instance.m_containerName.text = Localization.instance.Localize(_lastHoverContainer.GetInventory().GetName());
+            int containerWeight = Mathf.CeilToInt(_lastHoverContainer.GetInventory().GetTotalWeight());
+            InventoryGui.instance.m_containerWeight.text = containerWeight.ToString();
           } else {
-            InventoryGui.instance.m_container.gameObject.SetActive(false);
+            InventoryGui.instance.m_animator.SetBool("visible", false);
           }
         }
       }

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -1,14 +1,7 @@
 ﻿using BepInEx;
 using BepInEx.Configuration;
-
 using HarmonyLib;
-
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Reflection.Emit;
-
 using UnityEngine;
 
 namespace ContentsWithin {
@@ -21,13 +14,11 @@ namespace ContentsWithin {
     static ConfigEntry<bool> _isModEnabled;
     static ConfigEntry<KeyboardShortcut> _toggleShowContentsShortcut;
 
-    static bool _showContainerContents = true;
-    static bool _isInventoryInUse = false;
+    static bool isVisible;
 
     static Container _lastHoverContainer = null;
     static GameObject _lastHoverObject = null;
 
-    static InventoryGui _inventoryGui;
     static GameObject _inventoryPanel;
     static GameObject _containerPanel;
     static GameObject _infoPanel;
@@ -39,9 +30,6 @@ namespace ContentsWithin {
     public void Awake() {
       _isModEnabled = Config.Bind("_Global", "isModEnabled", true, "Globally enable or disable this mod.");
 
-      _isModEnabled.SettingChanged +=
-          (_, _) => Player.m_localPlayer.Ref()?.StartCoroutine(ToggleShowContainerContents(_isModEnabled.Value));
-
       _toggleShowContentsShortcut =
           Config.Bind(
               "Hotkeys",
@@ -52,83 +40,22 @@ namespace ContentsWithin {
       _harmony = Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly(), harmonyInstanceId: PluginGUID);
     }
 
-    public void OnDestroy() {
-      _harmony?.UnpatchSelf();
-    }
-
     [HarmonyPatch(typeof(Player))]
     class PlayerPatch {
-      [HarmonyTranspiler]
-      [HarmonyPatch(nameof(Player.Update))]
-      static IEnumerable<CodeInstruction> UpdateTranspiler(IEnumerable<CodeInstruction> instructions) {
-        return new CodeMatcher(instructions)
-            .MatchForward(
-                useEnd: false,
-                new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(Character), nameof(Character.TakeInput))),
-                new CodeMatch(OpCodes.Stloc_0))
-            .Advance(offset: 2)
-            .InsertAndAdvance(new CodeInstruction(OpCodes.Ldloc_0))
-            .InsertAndAdvance(Transpilers.EmitDelegate<Func<bool, bool>>(TakeInputDelegate))
-            .InsertAndAdvance(new CodeInstruction(OpCodes.Stloc_0))
-            .InstructionEnumeration();
-      }
-
-      static bool TakeInputDelegate(bool takeInputResult) {
-        if (!_isModEnabled.Value || !_toggleShowContentsShortcut.Value.IsDown()) {
-          return takeInputResult;
-        }
-
-        Player.m_localPlayer.Ref()?.StartCoroutine(ToggleShowContainerContents(!_showContainerContents));
-        return false;
-      }
-
       [HarmonyPostfix]
       [HarmonyPatch(nameof(Player.UpdateHover))]
-      static void UpdateHoverPostfix(ref Player __instance) {
+      public static void UpdateHoverPostfix(Player __instance) {
         if (!_isModEnabled.Value || _lastHoverObject == __instance.m_hovering) {
           return;
         }
 
         _lastHoverObject = __instance.m_hovering;
-        Player.m_localPlayer.Ref()?.StartCoroutine(ShowContainerContents(_lastHoverObject));
-      }
-    }
 
-    static IEnumerator ToggleShowContainerContents(bool toggle) {
-      yield return null;
-
-      _showContainerContents = toggle;
-
-      MessageHud.m_instance.ShowMessage(
-          MessageHud.MessageType.Center, $"ShowContainerContents: {_showContainerContents}");
-
-      if (_showContainerContents) {
-        _isInventoryInUse = _inventoryPanel.activeInHierarchy;
-        yield return ShowContainerContents(Player.m_localPlayer?.m_hovering);
-      } else {
-        if (_containerPanel.activeInHierarchy && !_isInventoryInUse && !_inventoryPanel.activeInHierarchy) {
-          _inventoryGui.Hide();
+        if (_lastHoverObject) {
+          _lastHoverContainer = _lastHoverObject.GetComponentInParent<Container>();
+        } else {
+          _lastHoverContainer = null;
         }
-      }
-    }
-
-    static IEnumerator ShowContainerContents(GameObject hoverObject) {
-      yield return null;
-
-      Container container = hoverObject.Ref()?.GetComponentInParent<Container>();
-      _lastHoverContainer = container;
-
-
-      if (!_showContainerContents || _isInventoryInUse) {
-        yield break;
-      }
-
-      if (container
-          && PrivateArea.CheckAccess(container.transform.position, 0f, false, false)
-          && container.CheckAccess(Game.m_instance.m_playerProfile.m_playerID)) {
-        _inventoryGui.Show(container);
-      } else if (_containerPanel && _containerPanel.activeSelf) {
-        _inventoryGui.Hide();
       }
     }
 
@@ -137,7 +64,6 @@ namespace ContentsWithin {
       [HarmonyPostfix]
       [HarmonyPatch(nameof(InventoryGui.Awake))]
       static void AwakePostfix(ref InventoryGui __instance) {
-        _inventoryGui = __instance;
         _inventoryPanel = __instance.m_player.Ref()?.gameObject;
         _containerPanel = __instance.m_container.Ref()?.gameObject;
         _infoPanel = __instance.m_infoPanel.Ref()?.gameObject;
@@ -145,117 +71,51 @@ namespace ContentsWithin {
         _takeAllButton = __instance.m_takeAllButton.Ref()?.gameObject;
       }
 
-      [HarmonyPostfix]
-      [HarmonyPatch(nameof(InventoryGui.IsVisible))]
-      static void IsVisiblePostfix(ref bool __result) {
-        if (_isModEnabled.Value && _lastHoverContainer && _showContainerContents && !_isInventoryInUse) {
-          __result = false;
-        }
-      }
-
-      [HarmonyPostfix]
+      [HarmonyPrefix]
       [HarmonyPatch(nameof(InventoryGui.Show))]
-      static void ShowPostfix(ref InventoryGui __instance, ref Container container) {
-        if (_isModEnabled.Value) {
-          _inventoryPanel.Ref()?.SetActive(!_showContainerContents || _isInventoryInUse || !container);
-          _craftingPanel.Ref()?.SetActive(container ? false : true);
-          _infoPanel.Ref()?.SetActive(container ? false : true);
-          _takeAllButton.Ref()?.SetActive(!_showContainerContents || _isInventoryInUse);
+      public static void ShowPostfix(InventoryGui __instance, ref Container container) {
+        isVisible = true;
+
+        if (_isModEnabled.Value && !container && _lastHoverContainer) {
+          container = _lastHoverContainer;
         }
       }
 
-      [HarmonyTranspiler]
-      [HarmonyPatch(nameof(InventoryGui.Update))]
-      static IEnumerable<CodeInstruction> UpdateTranspiler(IEnumerable<CodeInstruction> instructions) {
-        return new CodeMatcher(instructions)
-            .MatchForward(
-                useEnd: false,
-                new CodeMatch(
-                    OpCodes.Call, typeof(ZInput).GetMethod(nameof(ZInput.ResetButtonStatus), BindingFlags.Static)),
-                new CodeMatch(OpCodes.Ldarg_0),
-                new CodeMatch(OpCodes.Call, typeof(InventoryGui).GetMethod(nameof(InventoryGui.Hide))))
-            .Advance(offset: 2)
-            .SetInstructionAndAdvance(Transpilers.EmitDelegate<Action<InventoryGui>>(UpdateHideTranspiler))
-            .MatchForward(
-                useEnd: false,
-                new CodeMatch(OpCodes.Ldarg_0),
-                new CodeMatch(OpCodes.Ldnull),
-                new CodeMatch(OpCodes.Call, typeof(InventoryGui).GetMethod(nameof(InventoryGui.Show))))
-            .Advance(offset: 2)
-            .SetInstructionAndAdvance(Transpilers.EmitDelegate<Action<InventoryGui, Container>>(UpdateShowTranspiler))
-            .InstructionEnumeration();
+      [HarmonyPrefix]
+      [HarmonyPatch(nameof(InventoryGui.Hide))]
+      public static void HidePrefix(InventoryGui __instance) {
+        isVisible = false;
       }
 
-      static void UpdateHideTranspiler(InventoryGui inventoryGui) {
+      [HarmonyPrefix]
+      [HarmonyPatch(nameof(InventoryGui.Update))]
+      public static void UpdatePrefix(InventoryGui __instance) {
+        if (_isModEnabled.Value && !isVisible) {
+          __instance.m_animator.SetBool("visible", false);
+        }
+      }
+
+      [HarmonyPostfix]
+      [HarmonyPatch(nameof(InventoryGui.Update))]
+      public static void UpdatePostfix(InventoryGui __instance) {
+        _inventoryPanel.Ref()?.SetActive(!_isModEnabled.Value || isVisible);
+        _craftingPanel.Ref()?.SetActive(!_isModEnabled.Value || isVisible);
+        _infoPanel.Ref()?.SetActive(!_isModEnabled.Value || isVisible);
+        _takeAllButton.Ref()?.SetActive(!_isModEnabled.Value || isVisible);
+
         if (!_isModEnabled.Value) {
-          inventoryGui.Hide();
           return;
         }
 
-        if (_showContainerContents && !_isInventoryInUse && _lastHoverContainer) {
-          if (_lastHoverContainer.IsOwner()) {
-            _isInventoryInUse = true;
-            inventoryGui.Show(_lastHoverContainer);
+        if (!isVisible) {
+          if (_lastHoverContainer) {
+            InventoryGui.instance.m_animator.SetBool("visible", true);
+            InventoryGui.instance.m_container.gameObject.SetActive(true);
+            InventoryGui.instance.m_containerGrid.UpdateInventory(_lastHoverContainer.GetInventory(), null, null);
+            InventoryGui.instance.m_hiddenFrames = 10;
           } else {
-            _lastHoverContainer.Interact(Player.m_localPlayer, false, false);
+            InventoryGui.instance.m_container.gameObject.SetActive(false);
           }
-        } else {
-          inventoryGui.Hide();
-          _isInventoryInUse = false;
-        }
-      }
-
-      static void UpdateShowTranspiler(InventoryGui inventoryGui, Container container) {
-        if (_isModEnabled.Value) {
-          _isInventoryInUse = true;
-        }
-
-        inventoryGui.Show(container);
-      }
-
-      [HarmonyTranspiler]
-      [HarmonyPatch(nameof(InventoryGui.UpdateContainer))]
-      static IEnumerable<CodeInstruction> UpdateContainerTranspiler(IEnumerable<CodeInstruction> instructions) {
-        return new CodeMatcher(instructions)
-            .MatchForward(
-                useEnd: false,
-                new CodeMatch(OpCodes.Ldarg_0),
-                new CodeMatch(
-                    OpCodes.Ldfld,
-                    typeof(InventoryGui).GetField(
-                        nameof(InventoryGui.m_currentContainer), BindingFlags.Instance | BindingFlags.NonPublic)),
-                new CodeMatch(OpCodes.Callvirt, typeof(Container).GetMethod(nameof(Container.IsOwner))))
-            .Advance(offset: 2)
-            .SetInstructionAndAdvance(Transpilers.EmitDelegate<Func<Container, bool>>(UpdateContainerIsOwnerDelegate))
-            .InstructionEnumeration();
-      }
-
-      static bool UpdateContainerIsOwnerDelegate(Container container) {
-        if (_isModEnabled.Value && _showContainerContents && !_isInventoryInUse) {
-          return true;
-        }
-
-        return container.IsOwner();
-      }
-    }
-
-    [HarmonyPatch(typeof(Container))]
-    class ContainerPatch {
-      [HarmonyPrefix]
-      [HarmonyPatch(nameof(Container.SetInUse))]
-      static bool SetInUsePrefix() {
-        if (_isModEnabled.Value && _lastHoverContainer && _showContainerContents && !_isInventoryInUse) {
-          return false;
-        }
-
-        return true;
-      }
-
-      [HarmonyPrefix]
-      [HarmonyPatch(nameof(Container.RPC_OpenRespons))]
-      static void RpcOpenResponse(ref bool granted) {
-        if (_isModEnabled.Value && Player.m_localPlayer) {
-          _isInventoryInUse = granted;
         }
       }
     }

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -2,6 +2,7 @@
 using BepInEx.Configuration;
 using HarmonyLib;
 using System.Reflection;
+using BepInEx.Bootstrap;
 using UnityEngine;
 
 namespace ContentsWithin {
@@ -88,13 +89,17 @@ namespace ContentsWithin {
 
     [HarmonyPatch(typeof(InventoryGui))]
     public class InventoryGuiPatch {
-      [HarmonyPatch(nameof(InventoryGui.Awake)), HarmonyPostfix]
+      [HarmonyPatch(nameof(InventoryGui.Awake)), HarmonyPostfix, HarmonyPriority(Priority.Low)]
       public static void AwakePostfix(ref InventoryGui __instance) {
         _inventoryPanel = __instance.m_player.Ref()?.gameObject;
         _containerPanel = __instance.m_container.Ref()?.gameObject;
         _infoPanel = __instance.m_infoPanel.Ref()?.gameObject;
         _craftingPanel = __instance.m_inventoryRoot.Find("Crafting").Ref()?.gameObject;
         _takeAllButton = __instance.m_takeAllButton.Ref()?.gameObject;
+
+        if (Chainloader.PluginInfos.ContainsKey("randyknapp.mods.auga")) {
+          _craftingPanel = __instance.m_inventoryRoot.Find("RightPanel").Ref()?.gameObject;
+        }
       }
 
       [HarmonyPatch(nameof(InventoryGui.Show)), HarmonyPostfix]

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -122,6 +122,11 @@ namespace ContentsWithin {
         }
       }
 
+      [HarmonyPatch(nameof(InventoryGui.SetupDragItem)), HarmonyPrefix]
+      public static bool SetupDragItemPrefix() {
+        return ShowRealGUI();
+      }
+
       private static void ShowPreviewContainer() {
         InventoryGui.instance.m_animator.SetBool("visible", true);
         InventoryGui.instance.m_hiddenFrames = 10;

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -76,6 +76,16 @@ namespace ContentsWithin {
       }
     }
 
+    [HarmonyPatch(typeof(GuiBar))]
+    public class GuiBarPatch {
+      [HarmonyPatch(nameof(GuiBar.SetValue)), HarmonyPrefix]
+      public static void GuiBarSetValuePrefix(GuiBar __instance) {
+        if (__instance.m_firstSet) {
+          __instance.m_width = __instance.m_bar.sizeDelta.x;
+        }
+      }
+    }
+
     [HarmonyPatch(typeof(InventoryGui))]
     public class InventoryGuiPatch {
       [HarmonyPatch(nameof(InventoryGui.Awake)), HarmonyPostfix]

--- a/ContentsWithin/ContentsWithin.cs
+++ b/ContentsWithin/ContentsWithin.cs
@@ -115,11 +115,22 @@ namespace ContentsWithin {
           return;
         }
 
-        if (_lastHoverContainer && PrivateArea.CheckAccess(_lastHoverContainer.transform.position, 0f, false, false)) {
+        if (HasContainerAccess(_lastHoverContainer)) {
           ShowPreviewContainer();
         } else {
           InventoryGui.instance.m_animator.SetBool("visible", false);
         }
+      }
+
+      private static bool HasContainerAccess(Container container) {
+        if (!container) {
+          return false;
+        }
+
+        bool areaAccess = PrivateArea.CheckAccess(container.transform.position, 0f, false, false);
+        bool chestAccess = container.CheckAccess(Game.m_instance.m_playerProfile.m_playerID);
+
+        return areaAccess && chestAccess;
       }
 
       [HarmonyPatch(nameof(InventoryGui.SetupDragItem)), HarmonyPrefix]

--- a/ContentsWithin/ContentsWithin.csproj
+++ b/ContentsWithin/ContentsWithin.csproj
@@ -82,6 +82,9 @@
     <Reference Include="UnityEngine.UI">
       <HintPath>$(GamePath)\unstripped_corlib\UnityEngine.UI.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.AnimationModule">
+      <HintPath>$(GamePath)\unstripped_corlib\UnityEngine.AnimationModule.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ContentsWithin.cs" />


### PR DESCRIPTION
Changed the behaviour of ContentWithin to only use Pre-/Postfix GUI methods and no Transpiler. This makes it easier to maintain and doesn't conflict with mods that change container behaviour or also transpile player methods. Other mods that that change GUI may still conflict.