### PR TITLE
Pottery barn update

### DIFF
--- a/PotteryBarn/Patches/PiecePatch.cs
+++ b/PotteryBarn/Patches/PiecePatch.cs
@@ -12,22 +12,17 @@ namespace PotteryBarn {
   static class PiecePatch {
     [HarmonyPrefix]
     [HarmonyPatch(nameof(Piece.DropResources))]
-    public static void DropResourcePrefix(Piece __instance) {
+    public static bool DropResourcePrefix(Piece __instance) {
       // Should not need to check against cultivator creator shop items here because they do not pass the
       // Player.CanRemovePiece check.
       if (Requirements.hammerCreatorShopItems.Keys.Contains(__instance.m_description)) {
-        IsDropTableDisabled = true;
-      }
-
-      LogMessage($"Piece description {__instance.m_description}");
-
-      foreach (Piece.Requirement requirement in __instance.m_resources) {
-        GameObject gameObject = requirement.m_resItem.gameObject;
-
-        if (gameObject) {
-          LogMessage($"Dropping {gameObject.name}");
+        if (__instance.IsCreator()) {
+          IsDropTableDisabled = true;
+          return true;
         }
+        return false;
       }
+      return true;
     }
   }
 
@@ -40,14 +35,6 @@ namespace PotteryBarn {
         IsDropTableDisabled = false;
         return false;
       }
-
-      LogMessage($"Item destroyed not player made from Pottery barn. Using normal drop table. Dropping items:");
-      List<GameObject> dropList = __instance.m_dropWhenDestroyed.GetDropList();
-
-      for (int i = 0; i < dropList.Count; i++) {
-        LogMessage($"{dropList[i].name}");
-      }
-
       return true;
     }
   }

--- a/PotteryBarn/Patches/PlayerPatch.cs
+++ b/PotteryBarn/Patches/PlayerPatch.cs
@@ -85,12 +85,13 @@ namespace PotteryBarn.Patches {
     [HarmonyPatch(nameof(Player.CheckCanRemovePiece))]
     static bool CheckCanRemovePrefix(Player __instance, Piece piece, ref bool __result) {
       if (IsModEnabled.Value) {
+        // Prevents world generated piece from player removal with build hammer.
         if (!piece.IsPlacedByPlayer() && IsCreatorShopPiece(piece)) {
-          LogMessage("Cannot deconstruct world generated item using pottery barn.");
           __result = false;
           return false;
         }
 
+        // Prevents player from breaking pottery barn pieces they didn't create themselves.
         if (IsCreatorShopPiece(piece) && !piece.IsCreator()) {
           LogMessage("Cannot deconstruct pottery barn piece you did not build yourself.");
           __result = false;

--- a/PotteryBarn/Patches/PlayerPatch.cs
+++ b/PotteryBarn/Patches/PlayerPatch.cs
@@ -93,13 +93,12 @@ namespace PotteryBarn.Patches {
 
         // Prevents player from breaking pottery barn pieces they didn't create themselves.
         if (IsCreatorShopPiece(piece) && !piece.IsCreator()) {
-          LogMessage("Cannot deconstruct pottery barn piece you did not build yourself.");
           __result = false;
           return false;
         }
 
+        // Enforces destruction by damage rather than build hammer.
         if (!IsDestructibleCreatorShopPiece(piece) && IsCreatorShopPiece(piece)) {
-          LogMessage("This pottery barn piece cannot be deconstructed. You must destroy with damage.");
           __result = false;
           return false;
         }


### PR DESCRIPTION
Removed logging statements, added comments, and fixed bug where build requirements dropped instead of drop table on destruction of pottery barn piece with damage.