### PR TITLE
PotteryBarn v1.10.1

### DIFF
--- a/PotteryBarn/Core/Requirements.cs
+++ b/PotteryBarn/Core/Requirements.cs
@@ -101,10 +101,6 @@ namespace PotteryBarn {
           {"Tar", 10 },
           {"MushroomBlue", 10 }}},
 
-        {"demister_ball", new Dictionary<string, int>() {
-          {"Wisp", 10 },
-          {"MushroomBlue", 5 }}},
-
         {"dverger_demister", new Dictionary<string, int>() {
           {"Wisp", 20 },
           {"MushroomBlue", 8 }}},

--- a/PotteryBarn/PotteryBarn.cs
+++ b/PotteryBarn/PotteryBarn.cs
@@ -20,7 +20,7 @@ namespace PotteryBarn {
   public class PotteryBarn : BaseUnityPlugin {
     public const string PluginGuid = "redseiko.valheim.potterybarn";
     public const string PluginName = "PotteryBarn";
-    public const string PluginVersion = "1.10.0";
+    public const string PluginVersion = "1.10.1";
 
     Harmony _harmony;
 

--- a/PotteryBarn/README.md
+++ b/PotteryBarn/README.md
@@ -13,7 +13,6 @@
 
 | Demister              | Range | Blue Mushrooms | Wisps |
 |-----------------------|-------|----------------|-------|
-| demister_ball         | 12    | 5              | 10    |
 | dvergr_demister       | 15    | 8              | 20    |
 | dvergr_demister_large | 30    | 30             | 50    |
 
@@ -118,6 +117,10 @@
   * [Jotunn-v2.12.7](https://valheim.thunderstore.io/package/ValheimModding/Jotunn/)
 
 ## Changelog
+
+### 1.10.1
+
+  * Removed demister ball since it is untargetable and cannot be deconstructed by players
 
 ### 1.10.0
 

--- a/PotteryBarn/manifest.json
+++ b/PotteryBarn/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PotteryBarn",
-  "version_number": "1.10.0",
+  "version_number": "1.10.1",
   "website_url": "https://github.com/redseiko/ComfyMods/tree/main/PotteryBarn",
   "author": "ComfyMods",
   "description": "Public build extension that adds existing game prefabs to the Hammer.",


### PR DESCRIPTION
Removed demister ball since it is untargetable by players and cannot be deconstructed.