### PR TITLE
PotteryBarn v1.11.1

### DIFF
--- a/PotteryBarn/Core/DvergrPieces.cs
+++ b/PotteryBarn/Core/DvergrPieces.cs
@@ -56,9 +56,6 @@ namespace PotteryBarn {
       { "dvergrprops_wood_pole", new Dictionary<string, int>() {
         { "YggdrasilWood", 8 },
         { "Copper", 4 }}},
-      { "dvergrprops_wood_stake", new Dictionary<string, int>() {
-        { "YggdrasilWood", 2 },
-        { "Iron", 1 }}},
       { "dvergrprops_wood_wall", new Dictionary<string, int>() {
         { "YggdrasilWood", 32 },
         { "Copper", 16 }}},
@@ -122,8 +119,6 @@ namespace PotteryBarn {
         { "Wood", 1 }}},
       { "dvergrprops_wood_pole", new Dictionary<string, int>() {
         { "CopperScrap", 1 }}},
-      { "dvergrprops_wood_stake", new Dictionary<string, int>() {
-        { "Wood", 1 }}},
       { "dvergrprops_wood_wall", new Dictionary<string, int>() {
         { "Wood", 2 },
         { "CopperScrap", 1 }}},
@@ -161,7 +156,6 @@ namespace PotteryBarn {
       {"dvergrprops_curtain", "piece_workbench"},
       {"dvergrprops_wood_beam", "piece_workbench"},
       {"dvergrprops_wood_pole", "blackforge"},
-      {"dvergrprops_wood_stake", "blackforge"},
       {"dvergrprops_wood_wall", "blackforge"},
       {"dvergrtown_stair_corner_wood_left", "blackforge"},
       {"dvergrprops_lantern_standing", "blackforge"},

--- a/PotteryBarn/PotteryBarn.cs
+++ b/PotteryBarn/PotteryBarn.cs
@@ -20,7 +20,7 @@ namespace PotteryBarn {
   public class PotteryBarn : BaseUnityPlugin {
     public const string PluginGuid = "redseiko.valheim.potterybarn";
     public const string PluginName = "PotteryBarn";
-    public const string PluginVersion = "1.11.0";
+    public const string PluginVersion = "1.11.1";
 
     Harmony _harmony;
 

--- a/PotteryBarn/README.md
+++ b/PotteryBarn/README.md
@@ -43,7 +43,6 @@
 | Building    | dvergrprops_curtain               | Workbench        | 2x Yggdrasil wood  | 4x Blue jute       |                  |          |
 | Building    | dvergrprops_wood_beam             | Workbench        | 12x Yggdrasil wood |                    |                  |          |
 | Building    | dvergrprops_wood_pole             | Black Forge      | 8x Yggdrasil wood  | 4x Copper          |                  |          |
-| Building    | dvergrprops_wood_stake            | Black Forge      | 2x Yggdrasil wood  | 1x Iron            |                  |          |
 | Building    | dvergrprops_wood_wall             | Black Forge      | 32x Yggdrasil Wood | 16x Copper         |                  |          |
 | Building    | dvergrtown_stair_corner_wood_left | Black Forge      | 6x Yggdrasil Wood  | 3x Copper          |                  |          |
 | Building    | dvergrprops_lantern_standing      | Black Forge      | 1x Lantern         |                    |                  |          |
@@ -117,6 +116,10 @@
   * [Jotunn-v2.13.0](https://valheim.thunderstore.io/package/ValheimModding/Jotunn/)
 
 ## Changelog
+
+### 1.11.1
+
+  * Removed prefagb dvergrprops_wood_stake due to missing mesh on broken status.
 
 ### 1.11.0
 

--- a/PotteryBarn/manifest.json
+++ b/PotteryBarn/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PotteryBarn",
-  "version_number": "1.11.0",
+  "version_number": "1.11.1",
   "website_url": "https://github.com/redseiko/ComfyMods/tree/main/PotteryBarn",
   "author": "ComfyMods",
   "description": "Public build extension that adds existing game prefabs to the Hammer.",


### PR DESCRIPTION
. Removed prefab dvergr_stake_wall due to missing mesh on broken status.