### PR TITLE
LicenseToSkill v1.2.1 take 2. 

### DIFF
--- a/LicenseToSkill/LicenseToSkill.cs
+++ b/LicenseToSkill/LicenseToSkill.cs
@@ -36,7 +36,7 @@ namespace LicenseToSkill {
       UpdateHardDeathCooldownTimer();
 
       if (IsModEnabled.Value) {
-        Player.m_localPlayer.m_hardDeathCooldown = HardDeathCooldownOverride.Value;
+        Player.m_localPlayer.m_hardDeathCooldown = GetConfigHardDeathCooldown();
         return;
       }
 
@@ -54,7 +54,11 @@ namespace LicenseToSkill {
         return;
       }
 
-      hardDeathCooldown.m_ttl = HardDeathCooldownOverride.Value * 60f - Player.m_localPlayer.m_timeSinceDeath;
+      hardDeathCooldown.m_ttl = GetConfigHardDeathCooldown() - Player.m_localPlayer.m_timeSinceDeath;
+    }
+
+    public static float GetConfigHardDeathCooldown() {
+      return HardDeathCooldownOverride.Value * 60f;
     }
   }
 }

--- a/LicenseToSkill/Patches/PlayerPatch.cs
+++ b/LicenseToSkill/Patches/PlayerPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
-using UnityEngine;
+
+using static LicenseToSkill.LicenseToSkill;
 using static LicenseToSkill.PluginConfig;
 
 namespace LicenseToSkill {
@@ -12,7 +13,7 @@ namespace LicenseToSkill {
         return;
       }
 
-      __instance.m_hardDeathCooldown = HardDeathCooldownOverride.Value;
+      __instance.m_hardDeathCooldown = GetConfigHardDeathCooldown();
     }
 
     [HarmonyPostfix]
@@ -22,7 +23,7 @@ namespace LicenseToSkill {
         return;
       }
 
-      __result = __instance.m_timeSinceDeath > (HardDeathCooldownOverride.Value * 60f);
+      __result = __instance.m_timeSinceDeath > GetConfigHardDeathCooldown();
     }
   }
 }

--- a/LicenseToSkill/Patches/SEManPatch.cs
+++ b/LicenseToSkill/Patches/SEManPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 
+using static LicenseToSkill.LicenseToSkill;
 using static LicenseToSkill.PluginConfig;
 
 namespace LicenseToSkill {
@@ -16,7 +17,7 @@ namespace LicenseToSkill {
         return;
       }
 
-      __result.m_ttl = HardDeathCooldownOverride.Value * 60f;
+      __result.m_ttl = GetConfigHardDeathCooldown();
     }
   }
 }

--- a/LicenseToSkill/README.md
+++ b/LicenseToSkill/README.md
@@ -32,6 +32,7 @@
 ### 1.2.1
 
   * Fixed bug where soft death status effect re-appeared on HUD after finishing it's countdown.
+  * Fixed bug where hard death encountered after 10 minutes regardless of UI/mod enabled.
   * Updated assembly references to valheim_Data\Managed from unstripped_corlib.
 
 ### 1.2.0


### PR DESCRIPTION
Fixed reported bug where hard death encountered when mod enabled and UI still showed no skill drain.