### PR TITLE
Handle Negative Build Piece Index

### DIFF
--- a/SearsCatalog/SearsCatalog.cs
+++ b/SearsCatalog/SearsCatalog.cs
@@ -127,7 +127,7 @@ namespace SearsCatalog {
       Vector2Int gridIndex = Player.m_localPlayer.m_buildPieces.GetSelectedIndex();
       int index = (BuildHudColumns * gridIndex.y) + gridIndex.x;
 
-      if (index >= Hud.m_instance.m_pieceIcons.Count) {
+      if (index >= Hud.m_instance.m_pieceIcons.Count || index < 0) {
         return;
       }
 


### PR DESCRIPTION
Fix error caused by cloning pieces with InfinityHammer by adding a check to see if the selected index is negative to the existing check to see if it is out of bounds in the positive direction.