### PR TITLE
intermission: set black background behind all loading images

### DIFF
--- a/Intermission/CHANGELOG.md
+++ b/Intermission/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Unreleased
+
+  * Display a black background behind custom loading images for a consistent experience no matter the image or screen aspect ratio.
+
 ### 1.5.0
 
   * Updated for the `v0.217.46` patch.

--- a/Intermission/Core/HudUtils.cs
+++ b/Intermission/Core/HudUtils.cs
@@ -41,6 +41,15 @@ public static class HudUtils {
         .SetPreserveAspect(true);
   }
 
+  public static void SetupBlackBackground(Image loadingImage) {
+    // setting up an empty sprite as first sibling so that it's displayed behind seems to do the trick just fine
+    Transform backing = UnityEngine.Object.Instantiate(loadingImage.transform, loadingImage.transform.parent);
+    backing.name = "BlackBackground";
+    backing.GetComponent<Image>().sprite = null;
+    backing.SetActive(true);
+    backing.SetAsFirstSibling();
+  }
+
   public static void SetupPanelSeparator(Transform panelSeparator = default) {
     if (panelSeparator) {
       _cachedPanelSeparator = panelSeparator;

--- a/Intermission/Patches/FejdStartupPatch.cs
+++ b/Intermission/Patches/FejdStartupPatch.cs
@@ -14,6 +14,11 @@ static class FejdStartupPatch {
   static void AwakePostfix(ref FejdStartup __instance) {
     Image loadingImage = __instance.m_loading.transform.Find("Bkg").GetComponent<Image>();
 
+    // set black background as default backing such that the FejdStartup screen does not display the main menu behind
+    // loading images that do not scale up to the whole screen, and to avoid a visual discrepancy when the Hud screen
+    // takes over (since the Hud screen does have a black background built-in already)
+    HudUtils.SetupBlackBackground(loadingImage);
+
     // FejdStartup.m_menuAnimator locks the vanilla TMP_Text UI state, so work-around is to clone it to a new object.
     TMP_Text sourceLoadingText = __instance.m_loading.transform.Find("Text").GetComponent<TMP_Text>();
     TMP_Text loadingText = UnityEngine.Object.Instantiate(sourceLoadingText, __instance.m_loading.transform);

--- a/Intermission/Patches/SceneLoaderPatch.cs
+++ b/Intermission/Patches/SceneLoaderPatch.cs
@@ -27,6 +27,10 @@ static class SceneLoaderPatch {
       __instance._showSaveNotification = false;
       __instance._showHealthWarning = false;
 
+      // set black background as default backing such that the SceneLoader loading screen does not display the default
+      // Unity scene behind loading images that do not scale up to the whole screen
+      HudUtils.SetupBlackBackground(_loadingImage);
+
       HudUtils.SetupLoadingImage(_loadingImage);
       HudUtils.SetLoadingImage(_loadingImage);
       __instance.ScaleLerpLoadingImage(_loadingImage);


### PR DESCRIPTION
We add a black background behind the loading images displayed on the SceneLoader and FejdStartup screens, in order to hide whatever is behind them when the loading images do not scale up to the whole screen (e.g. displaying a 16:9 loading image on a 21:9 screen).

In particular, on the SceneLoader screen the default Unity scene was displayed, and on the FejdStartup screen the main menu was displayed (leading to a visual discrepancy when the Hud screen was taking over).